### PR TITLE
Handle positional arguments when converting format string

### DIFF
--- a/resources/src/iosMain/kotlin/dev/icerock/moko/resources/desc/StringDesc.kt
+++ b/resources/src/iosMain/kotlin/dev/icerock/moko/resources/desc/StringDesc.kt
@@ -86,7 +86,7 @@ actual sealed class StringDesc {
 
     protected fun stringWithFormat(format: String, args: Array<out Any>): String {
         // NSString format works with NSObjects via %@, we should change standard format to %@
-        val objcFormat = format.replace(Regex("%[\\.|\\d]*[a|b|c|d|e|f|s]"), "%@")
+        val objcFormat = format.replace(Regex("%((?:\\.|\\d|\\$)*)[abcdefs]"), "%$1@")
         // bad but objc interop limited :(
         // When calling variadic C functions spread operator is supported only for *arrayOf(...)
         return when (args.size) {


### PR DESCRIPTION
Format string regex looks slightly wrong (`[a|b|c|d|e|f|s]` part should just be `[abcdefs]`).
Also this regex does not handle positional arguments like `%2$s $1$d` (should be converted to `NSString` format as `%2$@ %1$@`).

This PR fixes both issues.

Thanks for a great library. I've wanted something like this since my first iOS project.