### PR TITLE
#60 enable anycase keys in strings and plurals on android

### DIFF
--- a/gradle-plugin/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidPluralsGenerator.kt
+++ b/gradle-plugin/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidPluralsGenerator.kt
@@ -74,6 +74,6 @@ class AndroidPluralsGenerator(
     }
 
     private fun processKey(key: String): String {
-        return key.replace(".", "_").toLowerCase()
+        return key.replace(".", "_")
     }
 }

--- a/gradle-plugin/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidStringsGenerator.kt
+++ b/gradle-plugin/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidStringsGenerator.kt
@@ -67,6 +67,6 @@ class AndroidStringsGenerator(
     }
 
     private fun processKey(key: String): String {
-        return key.replace(".", "_").toLowerCase()
+        return key.replace(".", "_")
     }
 }


### PR DESCRIPTION
now Strings and Plurals on android can have camelCase ids.
Files, Fonts, Images is filebased resources and can't have uppercased chars