### PR TITLE
#75: fat framework gradle task

### DIFF
--- a/gradle-plugin/src/main/kotlin/dev/icerock/gradle/generator/FatFrameworkWithResourcesTask.kt
+++ b/gradle-plugin/src/main/kotlin/dev/icerock/gradle/generator/FatFrameworkWithResourcesTask.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2020 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package dev.icerock.gradle.generator
 
 import org.gradle.api.tasks.TaskAction

--- a/gradle-plugin/src/main/kotlin/dev/icerock/gradle/generator/FatFrameworkWithResourcesTask.kt
+++ b/gradle-plugin/src/main/kotlin/dev/icerock/gradle/generator/FatFrameworkWithResourcesTask.kt
@@ -1,0 +1,24 @@
+package dev.icerock.gradle.generator
+
+import org.gradle.api.tasks.TaskAction
+import org.jetbrains.kotlin.gradle.tasks.FatFrameworkTask
+
+open class FatFrameworkWithResourcesTask : FatFrameworkTask() {
+
+    @TaskAction
+    protected fun copyBundle() {
+        super.createFatFramework()
+
+        frameworks.first().outputFile.listFiles()
+            ?.asSequence()
+            ?.filter { it.name.contains(".bundle") }
+            ?.forEach { bundleFile ->
+                project.copy {
+                    from(bundleFile) {
+                        into(bundleFile.name)
+                    }
+                    into(fatFrameworkDir)
+                }
+            }
+    }
+}


### PR DESCRIPTION
How to use the task in gradle `.kts` scripts with **mobile-multiplatform-gradle-plugin**:

```kotlin
kotlin {
    tasks.register("debugFatFramework", dev.icerock.gradle.generator.FatFrameworkWithResourcesTask::class) {
        baseName = "multiplatform"

        val targets = mapOf(
            "iosX64" to kotlin.targets.getByName<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>("iosX64"),
            "iosArm64" to kotlin.targets.getByName<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>("iosArm64")
        )

        from(
            targets.toList().map {
                it.second.binaries.getFramework("MultiPlatformLibrary", org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG)
            }
        )
    }
}
```