### PR TITLE
#77 new string resources extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,16 @@ In `commonMain/resources/MR/base/strings.xml` add:
 </resources>
 ```
 Then add the localized values for other languages like in example #1.
-Now create the followin function in `commonMain`:
+Now create the following function in `commonMain`:
 ```kotlin
 fun getMyFormatDesc(input: String): StringDesc {
   return StringDesc.ResourceFormatted(MR.strings.my_string_formatted, input)
+}
+```
+To create formatted strings from resources you can also use extension `format`:
+```kotlin
+fun getMyFormatDesc(input: String): StringDesc {
+  return MR.strings.my_string_formatted.format(input)
 }
 ```
 Now add support on the platform side like in example #1:  
@@ -203,6 +209,13 @@ Next, create a function in `commonMain`:
 fun getMyPluralFormattedDesc(quantity: Int): StringDesc {
   // we pass quantity as selector for correct plural string and for pass quantity as argument for formatting
   return StringDesc.PluralFormatted(MR.plurals.my_plural, quantity, quantity)  
+}
+```
+To create formatted plural strings from resources you can also use extension `format`:
+```kotlin
+fun getMyPluralFormattedDesc(quantity: Int): StringDesc {
+  // we pass quantity as selector for correct plural string and for pass quantity as argument for formatting
+  return MR.plurals.my_plural.format(quantity, quantity)  
 }
 ```
 And like in example #1, add the platform-side support:  

--- a/resources/src/androidMain/kotlin/dev/icerock/moko/resources/desc/CompositionStringDesc.kt
+++ b/resources/src/androidMain/kotlin/dev/icerock/moko/resources/desc/CompositionStringDesc.kt
@@ -7,7 +7,7 @@ package dev.icerock.moko.resources.desc
 import android.content.Context
 
 actual data class CompositionStringDesc actual constructor(
-    val args: List<StringDesc>,
+    val args: Iterable<StringDesc>,
     val separator: String?
 ) : StringDesc {
     override fun toString(context: Context): String {

--- a/resources/src/commonMain/kotlin/dev/icerock/moko/resources/PluralsResource.kt
+++ b/resources/src/commonMain/kotlin/dev/icerock/moko/resources/PluralsResource.kt
@@ -4,4 +4,10 @@
 
 package dev.icerock.moko.resources
 
+import dev.icerock.moko.resources.desc.PluralFormatted
+import dev.icerock.moko.resources.desc.StringDesc
+
 expect class PluralsResource
+
+fun PluralsResource.format(number: Int, vararg args: Any) = StringDesc.PluralFormatted(this, number, args)
+fun PluralsResource.format(number: Int, args: List<Any>) = StringDesc.PluralFormatted(this, number, args)

--- a/resources/src/commonMain/kotlin/dev/icerock/moko/resources/StringResource.kt
+++ b/resources/src/commonMain/kotlin/dev/icerock/moko/resources/StringResource.kt
@@ -4,4 +4,10 @@
 
 package dev.icerock.moko.resources
 
+import dev.icerock.moko.resources.desc.ResourceFormatted
+import dev.icerock.moko.resources.desc.StringDesc
+
 expect class StringResource
+
+fun StringResource.format(vararg args: Any) = StringDesc.ResourceFormatted(this, args)
+fun StringResource.format(args: List<Any>) = StringDesc.ResourceFormatted(this, args)

--- a/resources/src/commonMain/kotlin/dev/icerock/moko/resources/desc/CompositionStringDesc.kt
+++ b/resources/src/commonMain/kotlin/dev/icerock/moko/resources/desc/CompositionStringDesc.kt
@@ -4,10 +4,10 @@
 
 package dev.icerock.moko.resources.desc
 
-expect class CompositionStringDesc(args: List<StringDesc>, separator: String? = null) : StringDesc
+expect class CompositionStringDesc(args: Iterable<StringDesc>, separator: String? = null) : StringDesc
 
 @Suppress("FunctionName")
 fun StringDesc.Companion.Composition(
-    args: List<StringDesc>,
+    args: Iterable<StringDesc>,
     separator: String? = null
 ) = CompositionStringDesc(args, separator)

--- a/resources/src/commonMain/kotlin/dev/icerock/moko/resources/desc/StringDesc.kt
+++ b/resources/src/commonMain/kotlin/dev/icerock/moko/resources/desc/StringDesc.kt
@@ -26,3 +26,6 @@ fun PluralsResource.desc(number: Int) = StringDesc.Plural(this, number)
 operator fun StringDesc.plus(other: StringDesc): StringDesc {
     return StringDesc.Composition(listOf(this, other))
 }
+
+fun Iterable<StringDesc>.joinToStringDesc(separator: String = ", "): StringDesc =
+    StringDesc.Composition(this, separator)

--- a/resources/src/iosMain/kotlin/dev/icerock/moko/resources/desc/CompositionStringDesc.kt
+++ b/resources/src/iosMain/kotlin/dev/icerock/moko/resources/desc/CompositionStringDesc.kt
@@ -5,7 +5,7 @@
 package dev.icerock.moko.resources.desc
 
 actual data class CompositionStringDesc actual constructor(
-    val args: List<StringDesc>,
+    val args: Iterable<StringDesc>,
     val separator: String?
 ) : StringDesc {
     override fun localized(): String {

--- a/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/Testing.kt
+++ b/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/Testing.kt
@@ -8,7 +8,6 @@ import com.icerockdev.library.nested.nestedFile
 import com.icerockdev.library.nested.nestedTest
 import dev.icerock.moko.resources.FileResource
 import dev.icerock.moko.resources.ImageResource
-import dev.icerock.moko.resources.desc.Composition
 import dev.icerock.moko.resources.desc.Plural
 import dev.icerock.moko.resources.desc.PluralFormatted
 import dev.icerock.moko.resources.desc.Raw
@@ -16,7 +15,9 @@ import dev.icerock.moko.resources.desc.Resource
 import dev.icerock.moko.resources.desc.ResourceFormatted
 import dev.icerock.moko.resources.desc.StringDesc
 import dev.icerock.moko.resources.desc.desc
+import dev.icerock.moko.resources.desc.joinToStringDesc
 import dev.icerock.moko.resources.desc.plus
+import dev.icerock.moko.resources.format
 
 @Suppress("MagicNumber")
 object Testing {
@@ -46,6 +47,7 @@ object Testing {
 
         // create formatted string
         val formattedString = StringDesc.ResourceFormatted(MR.strings.format, 9)
+        val formattedStringExt = MR.strings.format.format(9)
 
         // create plural
         val simplePlural = StringDesc.Plural(MR.plurals.test_plural, 10)
@@ -53,6 +55,7 @@ object Testing {
 
         // create formatted plural
         val formattedPlural = StringDesc.PluralFormatted(MR.plurals.my_plural, 10, 10)
+        val formattedPluralExt = MR.plurals.my_plural.format(10, 10)
 
         // raw string
         val simpleRaw = StringDesc.Raw("raw string")
@@ -66,6 +69,7 @@ object Testing {
 
         // create
         val positional = StringDesc.ResourceFormatted(MR.strings.positional, 9, "str")
+        val positionalExt = MR.strings.positional.format(9 , "str")
 
         // result as list composition
         val list = listOf(
@@ -82,7 +86,7 @@ object Testing {
             positional
         )
 
-        return StringDesc.Composition(list, separator = "\n")
+        return list.joinToStringDesc("\n")
     }
 
     fun getFont1() = MR.fonts.Raleway.italic


### PR DESCRIPTION
Issue #77: 
* Add `format` extensions for `StringResource` and `PluralsResource`
* Add extension `joinToStringDesc` for `Iterable<StringDesc>` type