### PR TITLE
Release 0.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This is a Kotlin MultiPlatform library that provides access to the resources on 
   - 0.12.0
 - kotlin 1.4.0
   - 0.13.0
+  - 0.13.1
 
 ## Installation
 root build.gradle  
@@ -61,7 +62,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "dev.icerock.moko:resources-generator:0.13.0"
+        classpath "dev.icerock.moko:resources-generator:0.13.1"
     }
 }
 
@@ -78,7 +79,7 @@ project build.gradle
 apply plugin: "dev.icerock.mobile.multiplatform-resources"
 
 dependencies {
-    commonMainApi("dev.icerock.moko:resources:0.13.0")
+    commonMainApi("dev.icerock.moko:resources:0.13.1")
 }
 
 multiplatformResources {
@@ -364,8 +365,7 @@ Sample `mpp-hierarhical` contains usage of `org.jetbrains.kotlin.native.cocoapod
 ## Set Up Locally 
 - The [resources directory](resources) contains the `resources` library;
 - The [gradle-plugin directory](gradle-plugin) contains a gradle plugin with a `MR` class generator;
-- The [sample directory](sample) contains sample apps for Android and iOS; plus the mpp-library connected to the apps;
-- For local testing use the `./publishToMavenLocal.sh` script - so that sample apps use the locally published version.
+- The [sample directory](sample) contains sample apps for Android and iOS; plus the mpp-library connected to the apps.
 
 ## Contributing
 All development (both new features and bug fixes) is performed in the `develop` branch. This way `master` always contains the sources of the most recently released version. Please send PRs with bug fixes to the `develop` branch. Documentation fixes in the markdown files are an exception to this rule. They are updated directly in `master`.

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -19,7 +19,7 @@ object Deps {
 
     private const val mokoGraphicsVersion = "0.4.0"
     private const val mokoParcelizeVersion = "0.4.0"
-    const val mokoResourcesVersion = "0.13.0"
+    const val mokoResourcesVersion = "0.13.1"
 
     object Android {
         const val compileSdk = 28

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.enableCompatibilityMetadataVariant=true
 
 android.useAndroidX=true
-android.enableJetifier=true
 
 # Workaround for Bintray treating .sha512 files as artifacts
 # https://github.com/gradle/gradle/issues/11412

--- a/plugins/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/common/CommonMRGenerator.kt
+++ b/plugins/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/common/CommonMRGenerator.kt
@@ -8,6 +8,7 @@ import com.squareup.kotlinpoet.KModifier
 import dev.icerock.gradle.generator.MRGenerator
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompileCommon
 import java.io.File
 
 class CommonMRGenerator(
@@ -23,6 +24,9 @@ class CommonMRGenerator(
 ) {
     override fun getMRClassModifiers(): Array<KModifier> = arrayOf(KModifier.EXPECT)
 
-    @Suppress("EmptyFunctionBlock")
-    override fun apply(generationTask: Task, project: Project) {}
+    override fun apply(generationTask: Task, project: Project) {
+        project.tasks
+            .matching { it is KotlinCompileCommon }
+            .configureEach { it.dependsOn(generationTask) }
+    }
 }

--- a/sample/mpp-library/build.gradle.kts
+++ b/sample/mpp-library/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 
 dependencies {
     commonMainApi(Deps.Libs.MultiPlatform.mokoResources)
-    mppLibrary(Deps.Libs.MultiPlatform.mokoGraphics)
+    commonMainApi(Deps.Libs.MultiPlatform.mokoGraphics.common)
 
 // disabled while not fixed https://youtrack.jetbrains.com/issue/KT-41384
 //    commonMainImplementation(project("$path:nested-module"))


### PR DESCRIPTION
fix dependency of `compileCommonMainKotlinMetadata` to `generateMRcommon`
