### PR TITLE
#145: allow the usage of 'plurals' as an element

### DIFF
--- a/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/Testing.kt
+++ b/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/Testing.kt
@@ -41,8 +41,9 @@ object Testing {
             MR.strings.quotes.desc(),
             nestedTest(),
             MR.plurals.test_plural.desc(7),
-            MR.plurals.test_plural_interop.desc(0),
             MR.plurals.test_plural_interop.desc(1),
+            MR.plurals.test_plural_interop.desc(2),
+            MR.plurals.test_plural_interop.desc(7),
         )
     }
 

--- a/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/Testing.kt
+++ b/sample/mpp-library/src/commonMain/kotlin/com/icerockdev/library/Testing.kt
@@ -40,7 +40,9 @@ object Testing {
             MR.strings.multilined.desc(),
             MR.strings.quotes.desc(),
             nestedTest(),
-            MR.plurals.test_plural.desc(7)
+            MR.plurals.test_plural.desc(7),
+            MR.plurals.test_plural_interop.desc(0),
+            MR.plurals.test_plural_interop.desc(1),
         )
     }
 

--- a/sample/mpp-library/src/commonMain/resources/MR/base/plurals-test.xml
+++ b/sample/mpp-library/src/commonMain/resources/MR/base/plurals-test.xml
@@ -24,4 +24,13 @@
         <item quantity="many">%s many</item>
         <item quantity="other">%s other</item>
     </plural>
+    <!-- Verify that we can use the 'plurals' element. -->
+    <plurals name="test.plural.interop">
+        <item quantity="zero">interop: zero</item>
+        <item quantity="one">interop: one</item>
+        <item quantity="two">interop: two</item>
+        <item quantity="few">interop: few</item>
+        <item quantity="many">interop: many</item>
+        <item quantity="other">interop: other</item>
+    </plurals>
 </resources>

--- a/sample/mpp-library/src/commonMain/resources/MR/base/plurals-test.xml
+++ b/sample/mpp-library/src/commonMain/resources/MR/base/plurals-test.xml
@@ -26,11 +26,11 @@
     </plural>
     <!-- Verify that we can use the 'plurals' element. -->
     <plurals name="test.plural.interop">
-        <item quantity="zero">\'plurals\': zero</item>
-        <item quantity="one">\'plurals\': one</item>
-        <item quantity="two">\'plurals\': two</item>
-        <item quantity="few">\'plurals\': few</item>
-        <item quantity="many">\'plurals\': many</item>
-        <item quantity="other">\'plurals\': other</item>
+        <item quantity="zero">plurals-interop: zero</item>
+        <item quantity="one">plurals-interop: one</item>
+        <item quantity="two">plurals-interop: two</item>
+        <item quantity="few">plurals-interop: few</item>
+        <item quantity="many">plurals-interop: many</item>
+        <item quantity="other">plurals-interop: other</item>
     </plurals>
 </resources>

--- a/sample/mpp-library/src/commonMain/resources/MR/base/plurals-test.xml
+++ b/sample/mpp-library/src/commonMain/resources/MR/base/plurals-test.xml
@@ -26,11 +26,11 @@
     </plural>
     <!-- Verify that we can use the 'plurals' element. -->
     <plurals name="test.plural.interop">
-        <item quantity="zero">interop: zero</item>
-        <item quantity="one">interop: one</item>
-        <item quantity="two">interop: two</item>
-        <item quantity="few">interop: few</item>
-        <item quantity="many">interop: many</item>
-        <item quantity="other">interop: other</item>
+        <item quantity="zero">\'plurals\': zero</item>
+        <item quantity="one">\'plurals\': one</item>
+        <item quantity="two">\'plurals\': two</item>
+        <item quantity="few">\'plurals\': few</item>
+        <item quantity="many">\'plurals\': many</item>
+        <item quantity="other">\'plurals\': other</item>
     </plurals>
 </resources>

--- a/sample/mpp-library/src/commonMain/resources/MR/ru/plurals.xml
+++ b/sample/mpp-library/src/commonMain/resources/MR/ru/plurals.xml
@@ -10,12 +10,12 @@
     </plural>
     <!-- Verify that we can use the 'plurals' element. -->
     <plurals name="test.plural.interop">
-        <item quantity="zero">\'plurals\': ноль</item>
-        <item quantity="one">\'plurals\': один</item>
-        <item quantity="two">\'plurals\': два</item>
-        <item quantity="few">\'plurals\': несколько</item>
-        <item quantity="many">\'plurals\': много</item>
-        <item quantity="other">\'plurals\': другое</item>
+        <item quantity="zero">plurals-interop: ноль</item>
+        <item quantity="one">plurals-interop: один</item>
+        <item quantity="two">plurals-interop: два</item>
+        <item quantity="few">plurals-interop: несколько</item>
+        <item quantity="many">plurals-interop: много</item>
+        <item quantity="other">plurals-interop: другое</item>
     </plurals>
     <plural name="my_plural">
         <item quantity="zero">нет элементов</item>

--- a/sample/mpp-library/src/commonMain/resources/MR/ru/plurals.xml
+++ b/sample/mpp-library/src/commonMain/resources/MR/ru/plurals.xml
@@ -8,6 +8,15 @@
         <item quantity="many">много</item>
         <item quantity="other">другое</item>
     </plural>
+    <!-- Verify that we can use the 'plurals' element. -->
+    <plurals name="test.plural.interop">
+        <item quantity="zero">\'plurals\': ноль</item>
+        <item quantity="one">\'plurals\': один</item>
+        <item quantity="two">\'plurals\': два</item>
+        <item quantity="few">\'plurals\': несколько</item>
+        <item quantity="many">\'plurals\': много</item>
+        <item quantity="other">\'plurals\': другое</item>
+    </plurals>
     <plural name="my_plural">
         <item quantity="zero">нет элементов</item>
         <item quantity="one">%d элемент</item>

--- a/sample/mpp-library/src/commonTest/kotlin/com/icerock/library/StringResourceTests.kt
+++ b/sample/mpp-library/src/commonTest/kotlin/com/icerock/library/StringResourceTests.kt
@@ -50,7 +50,7 @@ class StringResourceTests: BaseUnitTest() {
             expected = "тест\nтест 2\nтест 3\nТестовый проект\nsome raw string\nодин\n" +
                     "несколько\nнесколько\nпервая строка\nвторая строка\nтретья строка.\n" +
                     "Alex009 сказал \"привет мир\" & \"пишите тесты\".\nтест вложенный\nмного\n" +
-                    "'plurals': много\n'plurals': один",
+                    "plurals-interop: один\nplurals-interop: несколько\nplurals-interop: много",
             actual = rawString
         )
     }
@@ -64,7 +64,7 @@ class StringResourceTests: BaseUnitTest() {
             expected = "test\ntest 2\ntest 3\nTest Project\nsome raw string\none\nother\n" +
                     "other\nfirst line\nsecond line\nthird line.\n" +
                     "Alex009 said \"hello world\" & \"write tests\".\nnested test\nother\n" +
-                    "'plurals': other\n'plurals': one",
+                    "plurals-interop: one\nplurals-interop: other\nplurals-interop: other",
             actual = rawString
         )
     }

--- a/sample/mpp-library/src/commonTest/kotlin/com/icerock/library/StringResourceTests.kt
+++ b/sample/mpp-library/src/commonTest/kotlin/com/icerock/library/StringResourceTests.kt
@@ -49,7 +49,8 @@ class StringResourceTests: BaseUnitTest() {
         assertEquals(
             expected = "тест\nтест 2\nтест 3\nТестовый проект\nsome raw string\nодин\n" +
                     "несколько\nнесколько\nпервая строка\nвторая строка\nтретья строка.\n" +
-                    "Alex009 сказал \"привет мир\" & \"пишите тесты\".\nтест вложенный\nмного",
+                    "Alex009 сказал \"привет мир\" & \"пишите тесты\".\nтест вложенный\nмного\n" +
+                    "'plurals': много\n'plurals': один",
             actual = rawString
         )
     }
@@ -62,7 +63,8 @@ class StringResourceTests: BaseUnitTest() {
         assertEquals(
             expected = "test\ntest 2\ntest 3\nTest Project\nsome raw string\none\nother\n" +
                     "other\nfirst line\nsecond line\nthird line.\n" +
-                    "Alex009 said \"hello world\" & \"write tests\".\nnested test\nother",
+                    "Alex009 said \"hello world\" & \"write tests\".\nnested test\nother\n" +
+                    "'plurals': other\n'plurals': one",
             actual = rawString
         )
     }


### PR DESCRIPTION
`plurals` match the element name used on the Android platform.
This allows us to upload the source xml as-is to translation websites as they'll
interpret it as an Android resource file.

Fixes #145.