### PR TITLE
Adds arm64 target for the simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![badge][badge-android]
 ![badge][badge-iosx64]
 ![badge][badge-iosarm64]
+![badge][badge-iosSimulatorArm64]
 ![badge][badge-macos64]
 ![badge][badge-jvm]
 
@@ -542,4 +543,5 @@ For more details on contributing please see the [contributing guide](CONTRIBUTIN
 [badge-nodejs]: https://img.shields.io/badge/platform-nodejs-68a063.svg?style=flat
 [badge-iosx64]: https://img.shields.io/badge/platform-iosx64-CDCDCD?style=flat
 [badge-iosarm64]: https://img.shields.io/badge/platform-iosarm64-CDCDCD?style=flat
-[badge-macos64]: https://img.shields.io/badge/platform-macos64-111111?style=flat    
+[badge-iosSimulatorArm64]: https://img.shields.io/badge/platform-iosSimulatorArm64-CDCDCD?style=flat
+[badge-macos64]: https://img.shields.io/badge/platform-macos64-111111?style=flat

--- a/sample/mpp-library/build.gradle.kts
+++ b/sample/mpp-library/build.gradle.kts
@@ -43,7 +43,8 @@ tasks.register("debugFatFramework", dev.icerock.gradle.tasks.FatFrameworkWithRes
 
     val targets = mapOf(
         "iosX64" to kotlin.targets.getByName<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>("iosX64"),
-        "iosArm64" to kotlin.targets.getByName<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>("iosArm64")
+        "iosArm64" to kotlin.targets.getByName<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>("iosArm64"),
+        "iosSimulatorArm64" to kotlin.targets.getByName<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>("iosSimulatorArm64")
     )
 
     from(

--- a/sample/mpp-mixed/build.gradle.kts
+++ b/sample/mpp-mixed/build.gradle.kts
@@ -30,6 +30,12 @@ kotlin {
             isStatic = false
         }
     }
+    iosSimulatorArm64 {
+        binaries.framework {
+            baseName = "MultiPlatformLibrary"
+            isStatic = false
+        }
+    }
 
     sourceSets {
         val iosX64Main by getting {}
@@ -41,6 +47,12 @@ kotlin {
             dependsOn(iosMiddle)
         }
         val iosArm64Test by getting {
+            dependsOn(iosX64Test)
+        }
+        val iosSimulatorArm64Main by getting {
+            dependsOn(iosMiddle)
+        }
+        val iosSimulatorArm64Test by getting {
             dependsOn(iosX64Test)
         }
     }


### PR DESCRIPTION
#248 Adds arm64 support to enable moko to be used with Apple Silicon simulators