### PR TITLE
Kotlin cocoapods 1.6 - Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,18 +124,10 @@ you also need to pass extra properties:
     -Pmoko.resources.CONFIGURATION=$CONFIGURATION \
     -Pmoko.resources.BUILT_PRODUCTS_DIR=$BUILT_PRODUCTS_DIR \
     -Pmoko.resources.CONTENTS_FOLDER_PATH=$CONTENTS_FOLDER_PATH\
-    -Pkotlin.native.cocoapods.target=$KOTLIN_TARGET \
-    -Pkotlin.native.cocoapods.configuration=$CONFIGURATION \
-    -Pkotlin.native.cocoapods.cflags="$OTHER_CFLAGS" \
-    -Pkotlin.native.cocoapods.paths.headers="$HEADER_SEARCH_PATHS" \
-    -Pkotlin.native.cocoapods.paths.frameworks="$FRAMEWORK_SEARCH_PATHS"
+    -Pkotlin.native.cocoapods.platform=$PLATFORM_NAME \
+    -Pkotlin.native.cocoapods.archs="$ARCHS" \
+    -Pkotlin.native.cocoapods.configuration=$CONFIGURATION 
 ```
-and setup extra build settings in your xcode target:
-```
-'KOTLIN_TARGET[sdk=iphonesimulator*]' => 'ios_x64'
-'KOTLIN_TARGET[sdk=iphoneos*]' => 'ios_arm64'
-```
-[here example of changes](https://github.com/ln-12/moko-resources-issue-99/pull/2/files)
 
 ## Usage
 ### Example 1 - simple localization string


### PR DESCRIPTION
new kotlin plugin of cocoapods has new gradle properties.

```
                    -Pkotlin.native.cocoapods.platform=$PLATFORM_NAME \
                    -Pkotlin.native.cocoapods.archs="$ARCHS" \
                    -Pkotlin.native.cocoapods.configuration=$CONFIGURATION
```

KOTLIN_TARGET properties are obsolete