### PR TITLE
ios color asset support for runtime dark & light color switching 

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ multiplatformResources {
 }
 ```
 
+To use `toUIColor()`, `toUIImage()`, `desc()` and other iOS extensions from Swift - you should [add `export` declarations](https://kotlinlang.org/docs/multiplatform-build-native-binaries.html#export-dependencies-to-binaries):
+```
+framework {
+    export("dev.icerock.moko:resources:0.20.1")
+    export("dev.icerock.moko:graphics:0.9.0") // toUIColor here
+}
+```
+
 If your project includes a build type, for example `staging` which isn't in moko-resources. That isn't an issue. Use matchingFallbacks to specify alternative matches for a given build type, as shown below
 ```
 buildTypes {

--- a/resources-test/src/commonMain/kotlin/dev/icerock/moko/resources/test/createColorResourceMock.kt
+++ b/resources-test/src/commonMain/kotlin/dev/icerock/moko/resources/test/createColorResourceMock.kt
@@ -7,4 +7,4 @@ package dev.icerock.moko.resources.test
 import dev.icerock.moko.graphics.Color
 import dev.icerock.moko.resources.ColorResource
 
-fun createColorResourceMock(): ColorResource = ColorResource.Single(Color(0, 0, 0, 0),"black")
+fun createColorResourceMock(): ColorResource = ColorResource.Single(Color(0, 0, 0, 0), "black")

--- a/resources/src/commonMain/kotlin/dev/icerock/moko/resources/ColorResource.kt
+++ b/resources/src/commonMain/kotlin/dev/icerock/moko/resources/ColorResource.kt
@@ -6,7 +6,7 @@ package dev.icerock.moko.resources
 
 import dev.icerock.moko.graphics.Color
 
-sealed class ColorResource(val name:String) {
+sealed class ColorResource(val name: String) {
     class Single(val color: Color, name: String) : ColorResource(name)
 
     class Themed(val light: Color, val dark: Color, name: String) : ColorResource(name)

--- a/resources/src/iosMain/kotlin/dev/icerock/moko/resources/ColorResourceExt.kt
+++ b/resources/src/iosMain/kotlin/dev/icerock/moko/resources/ColorResourceExt.kt
@@ -26,7 +26,8 @@ fun ColorResource.getColor(userInterfaceStyle: UIUserInterfaceStyle): Color {
 }
 
 /**
- * Returns null if no color asset is found in the ios app. update and configure copyColorAssetsToIOSApp in your ios run script to automate the copy process.
+ * Returns null if no color asset is found in the ios app.
+ * update and configure copyColorAssetsToIOSApp in your ios run script to automate the copy process.
  *       val copyColorAssetsToIOSApp = tasks.register<Copy>("copyColorAssetsToIOSApp") {
  *              from("$rootDir/resources/build/generated/moko/iosMain/res/Assets.xcassets")
  *              into("$rootDir/iosApp/iosApp/Assets.xcassets/colors")


### PR DESCRIPTION
To support runtime theme switch the generated color assets files need to be copied to iosApp. which can be automated by a gradle task like below and configure it as iOS  run script.

val copyColorAssetsToIOSApp = tasks.register<Copy>("copyColorAssetsToIOSApp") {
    from("$rootDir/resources/build/generated/moko/iosMain/res/Assets.xcassets")
    into("$rootDir/iosApp/iosApp/Assets.xcassets/colors")
}

Now to get the color from the iOS app assets we need to use UIColor.colorNamed(“colorName”) function. Below extension method can be used for that

fun ColorResource.getThemeColor(): UIColor {
   return UIColor.colorNamed(this.name)!!
}