### PR TITLE
Always use forward slash for JVM resources

### DIFF
--- a/resources/src/jvmMain/kotlin/dev/icerock/moko/resources/ResourceContainer.kt
+++ b/resources/src/jvmMain/kotlin/dev/icerock/moko/resources/ResourceContainer.kt
@@ -4,7 +4,6 @@
 
 package dev.icerock.moko.resources
 
-import java.io.File
 import java.io.FileNotFoundException
 
 actual interface ResourceContainer<T> {
@@ -30,6 +29,6 @@ actual fun ResourceContainer<AssetResource>.getAssetByFilePath(filePath: String)
     return AssetResource(
         resourcesClassLoader,
         originalPath,
-        "files${File.separatorChar}$originalPath"
+        "files/$originalPath"
     )
 }


### PR DESCRIPTION
When using `File.separatorChar` to specify the asset path, Windows JVM clients will return `null` when `getResource()` is called, since that method expects a `/`-separated path, not a `\`-separated path, on all platforms.

https://bitmingw.com/2020/05/16/do-not-use-file-separator-when-loading-java-resource-files/
https://docs.oracle.com/javase/8/docs/api/java/lang/ClassLoader.html#getResource-java.lang.String-