### PR TITLE
Update ResourceStringDesc.kt

### DIFF
--- a/resources/src/appleMain/kotlin/dev/icerock/moko/resources/desc/ResourceStringDesc.kt
+++ b/resources/src/appleMain/kotlin/dev/icerock/moko/resources/desc/ResourceStringDesc.kt
@@ -8,7 +8,7 @@ import dev.icerock.moko.parcelize.Parcelable
 import dev.icerock.moko.resources.StringResource
 
 actual data class ResourceStringDesc actual constructor(
-    private val stringRes: StringResource
+    val stringRes: StringResource
 ) : StringDesc, Parcelable {
     override fun localized(): String {
         return Utils.localizedString(stringRes)


### PR DESCRIPTION
Make stringRes public according to other desc classes.

This change will allow you to create your own implementation of the localized() method for ResourceStringDesc. This can be useful, for example, when implementing the localized(StringDesc.localeType) method, with a unique locale for a single stringDesc.