### PR TITLE
use forward slash when generating assets for file paths in js

### DIFF
--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/js/JsAssetsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/js/JsAssetsGenerator.kt
@@ -28,7 +28,7 @@ class JsAssetsGenerator(
         val filePath = File(FILES_DIR, fileSpec.pathRelativeToBase).path
         return CodeBlock.of("""
             AssetResource(
-                originalPath = js("require(\"$filePath\")") as String, 
+                originalPath = js("require(\"${filePath.replace("\\","/")}\")") as String, 
                 rawPath = "${fileSpec.pathRelativeToBase}"
             )
         """.trimIndent())


### PR DESCRIPTION
this is fixed by a forward slash rather than backslash on js