### PR TITLE
escape backslashes to fix path on windows in js

### DIFF
--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/js/JsMRGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/js/JsMRGenerator.kt
@@ -152,7 +152,7 @@ class JsMRGenerator(
                 """
                 const path = require('path');
 
-                const mokoResourcePath = path.resolve("${resourcesOutput.absolutePath}");
+                const mokoResourcePath = path.resolve("${resourcesOutput.absolutePath.replace("\\","\\\\")}");
 
                 config.module.rules.push(
                     {


### PR DESCRIPTION
with this pull request , this issue does not occur in development mode, when building for production mode you might get this error , if you don't perform a clean build before building the production , I experienced this on windows with compose web
https://github.com/icerockdev/moko-resources/issues/409