### PR TITLE
compose-web target with asset resource and string resource

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ kotlin.mpp.stability.nowarn=true
 kotlin.native.enableDependencyPropagation=false
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.enableCompatibilityMetadataVariant=true
+org.jetbrains.compose.experimental.jscanvas.enabled=true
 
 android.useAndroidX=true
 

--- a/resources-compose/build.gradle.kts
+++ b/resources-compose/build.gradle.kts
@@ -28,6 +28,9 @@ android {
 
 kotlin {
     jvm()
+    js(IR) {
+        browser()
+    }
     sourceSets {
         commonMain {
             dependencies {

--- a/resources-compose/src/androidMain/kotlin/dev/icerock/moko/resources/compose/AssetResource.kt
+++ b/resources-compose/src/androidMain/kotlin/dev/icerock/moko/resources/compose/AssetResource.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.resources.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.platform.LocalContext
+import dev.icerock.moko.resources.AssetResource
+
+@Composable
+actual fun AssetResource.readTextAsState(): State<String> {
+    val context = LocalContext.current
+    return produceState("") {
+        value = readText(context)
+    }
+}

--- a/resources-compose/src/commonMain/kotlin/dev/icerock/moko/resources/compose/AssetResource.kt
+++ b/resources-compose/src/commonMain/kotlin/dev/icerock/moko/resources/compose/AssetResource.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2023 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.resources.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import dev.icerock.moko.resources.AssetResource
+
+@Composable
+expect fun AssetResource.readTextAsState(): State<String>

--- a/resources-compose/src/jsMain/kotlin/dev/icerock/moko/resources/compose/AssetResource.kt
+++ b/resources-compose/src/jsMain/kotlin/dev/icerock/moko/resources/compose/AssetResource.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.resources.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.produceState
+import dev.icerock.moko.resources.AssetResource
+
+@Composable
+actual fun AssetResource.readTextAsState(): State<String> {
+    return produceState("") {
+        value = getText()
+    }
+}

--- a/resources-compose/src/jsMain/kotlin/dev/icerock/moko/resources/compose/StringDescExt.kt
+++ b/resources-compose/src/jsMain/kotlin/dev/icerock/moko/resources/compose/StringDescExt.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.resources.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.produceState
+import dev.icerock.moko.resources.desc.StringDesc
+
+@Composable
+actual fun StringDesc.localized(): String {
+    return produceState("") {
+        value = localized()
+    }.value
+}

--- a/resources-compose/src/jsMain/kotlin/dev/icerock/moko/resources/compose/StringResource.kt
+++ b/resources-compose/src/jsMain/kotlin/dev/icerock/moko/resources/compose/StringResource.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.resources.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.produceState
+import dev.icerock.moko.resources.PluralsResource
+import dev.icerock.moko.resources.StringResource
+import dev.icerock.moko.resources.desc.Plural
+import dev.icerock.moko.resources.desc.PluralFormatted
+import dev.icerock.moko.resources.desc.Resource
+import dev.icerock.moko.resources.desc.ResourceFormatted
+import dev.icerock.moko.resources.desc.StringDesc
+
+@Composable
+actual fun stringResource(resource: StringResource): String =
+    produceState("") { value = StringDesc.Resource(resource).localized() }.value
+
+@Composable
+actual fun stringResource(resource: StringResource, vararg args: Any): String =
+    produceState("") { value = StringDesc.ResourceFormatted(resource, *args).localized() }.value
+
+@Composable
+actual fun stringResource(resource: PluralsResource, quantity: Int): String =
+    produceState("") { value = StringDesc.Plural(resource, quantity).localized() }.value
+
+@Composable
+actual fun stringResource(resource: PluralsResource, quantity: Int, vararg args: Any): String =
+    produceState("") { value = StringDesc.PluralFormatted(resource, quantity, *args).localized() }.value

--- a/resources-compose/src/jvmMain/kotlin/dev/icerock/moko/resources/compose/AssetResource.kt
+++ b/resources-compose/src/jvmMain/kotlin/dev/icerock/moko/resources/compose/AssetResource.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.resources.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.produceState
+import dev.icerock.moko.resources.AssetResource
+
+@Composable
+actual fun AssetResource.readTextAsState(): State<String> {
+    return produceState("") {
+        value = readText()
+    }
+}


### PR DESCRIPTION
adds a web target to resources-compose and adds a expect function for asset resource to get text in a multiplatform way