### PR TITLE
Workaround #311: Support for Gradle configuration cache

### DIFF
--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/tasks/GenerateMultiplatformResourcesTask.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/tasks/GenerateMultiplatformResourcesTask.kt
@@ -31,6 +31,7 @@ open class GenerateMultiplatformResourcesTask : DefaultTask() {
 
     @TaskAction
     fun generate() {
+        notCompatibleWithConfigurationCache("This library needs to be rewritten to remove all references to non-serializable objects... See moko-resources#311")
         generator.generate()
     }
 }


### PR DESCRIPTION
Setting `notCompatibleWithConfigurationCache()` on `GenerateMultiplatformResourcesTask` should likely be sufficient to work around the issue for #311. Work to allow config caching can be backlogged for later while this prevents fatal errors.

I tested locally and it seemed to work. I was able to enable config cache for all other tasks without encountering any breaking errors with moko-resources.