### PR TITLE
Configure plugin more lazily

### DIFF
--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/FilesGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/FilesGenerator.kt
@@ -107,7 +107,7 @@ abstract class FilesGenerator(
 
         override fun createAndroidGenerator() = AndroidFilesGenerator(
             inputFileTree = fileTree,
-            getAndroidRClassPackage = requireNotNull(info.getAndroidRClassPackage)
+            androidRClassPackageProvider = requireNotNull(info.androidRClassPackageProvider),
         )
 
         override fun createJsGenerator(): FilesGenerator = JsFilesGenerator(fileTree)

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/FontsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/FontsGenerator.kt
@@ -135,7 +135,7 @@ abstract class FontsGenerator(
 
         override fun createAndroidGenerator() = AndroidFontsGenerator(
             inputFileTree = stringsFileTree,
-            getAndroidRClassPackage = requireNotNull(info.getAndroidRClassPackage)
+            androidRClassPackageProvider = requireNotNull(info.androidRClassPackageProvider)
         )
 
         override fun createJsGenerator(): FontsGenerator = JsFontsGenerator(

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/ImagesGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/ImagesGenerator.kt
@@ -113,7 +113,7 @@ abstract class ImagesGenerator(
 
         override fun createAndroidGenerator() = AndroidImagesGenerator(
             inputFileTree = stringsFileTree,
-            getAndroidRClassPackage = requireNotNull(info.getAndroidRClassPackage),
+            androidRClassPackageProvider = requireNotNull(info.androidRClassPackageProvider),
             logger = logger
         )
 

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/MRGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/MRGenerator.kt
@@ -14,40 +14,28 @@ import dev.icerock.gradle.tasks.GenerateMultiplatformResourcesTask
 import dev.icerock.gradle.toModifier
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import java.io.File
 
 abstract class MRGenerator(
-    generatedDir: File,
+    generatedDir: Provider<Directory>,
     protected val sourceSet: SourceSet,
     protected val mrSettings: MRSettings,
     internal val generators: List<Generator>
 ) {
-
-    internal val outputDir = File(generatedDir, sourceSet.name)
-    protected open val sourcesGenerationDir
-        get() = File(outputDir, "src")
-    protected open val resourcesGenerationDir
-        get() = File(outputDir, "res")
-
-    protected open val assetsGenerationDir: File
-        get() = File(outputDir, AssetsGenerator.ASSETS_DIR_NAME)
-
-    init {
-        setupGenerationDirs()
-    }
-
-    private fun setupGenerationDirs() {
-        sourcesGenerationDir.mkdirs()
-        sourceSet.addSourceDir(sourcesGenerationDir)
-
-        resourcesGenerationDir.mkdirs()
-        sourceSet.addResourcesDir(resourcesGenerationDir)
-
-        assetsGenerationDir.mkdirs()
-        sourceSet.addAssetsDir(assetsGenerationDir)
+    internal val outputDir: Provider<Directory> = generatedDir.map { it.dir(sourceSet.name) }
+    protected open val sourcesGenerationDir: Provider<Directory> = outputDir.map { it.dir("src") }
+    protected open val resourcesGenerationDir: Provider<Directory> = outputDir.map { it.dir("res") }
+    protected open val assetsGenerationDir: Provider<Directory> = outputDir.map {
+        it.dir(AssetsGenerator.ASSETS_DIR_NAME)
     }
 
     internal fun generate() {
+        val sourcesGenerationDir = sourcesGenerationDir.get().asFile
+        val assetsGenerationDir = assetsGenerationDir.get().asFile
+        val resourcesGenerationDir = resourcesGenerationDir.get().asFile
+
         sourcesGenerationDir.deleteRecursively()
         resourcesGenerationDir.deleteRecursively()
         assetsGenerationDir.deleteRecursively()
@@ -55,13 +43,13 @@ abstract class MRGenerator(
         beforeMRGeneration()
 
         @Suppress("SpreadOperator")
-        val mrClassSpec = TypeSpec.objectBuilder(mrSettings.className)
+        val mrClassSpec = TypeSpec.objectBuilder(mrSettings.className.get())
             .addModifiers(*getMRClassModifiers())
-            .addModifiers(mrSettings.visibility.toModifier())
+            .addModifiers(mrSettings.visibility.get().toModifier())
 
         generators.forEach { generator ->
             val builder = TypeSpec.objectBuilder(generator.mrObjectName)
-                .addModifiers(mrSettings.visibility.toModifier())
+                .addModifiers(mrSettings.visibility.get().toModifier())
 
             val fileResourceInterfaceClassName =
                 ClassName("dev.icerock.moko.resources", "ResourceContainer")
@@ -80,7 +68,7 @@ abstract class MRGenerator(
 
         val mrClass = mrClassSpec.build()
 
-        val fileSpec = FileSpec.builder(mrSettings.packageName, mrSettings.className)
+        val fileSpec = FileSpec.builder(mrSettings.packageName.get(), mrSettings.className.get())
             .addType(mrClass)
 
         generators
@@ -97,6 +85,7 @@ abstract class MRGenerator(
     fun apply(project: Project): GenerateMultiplatformResourcesTask {
         val name = sourceSet.name
         val genTaskName = "generateMR$name"
+        setupGenerationDirs()
         val genTask = runCatching {
             project.tasks.getByName(genTaskName) as GenerateMultiplatformResourcesTask
         }.getOrNull() ?: project.tasks.create(
@@ -104,6 +93,9 @@ abstract class MRGenerator(
             GenerateMultiplatformResourcesTask::class.java
         ) {
             it.generator = this
+            it.inputs.property("mokoSettingsPackageName", mrSettings.packageName)
+            it.inputs.property("mokoSettingsClassName", mrSettings.className)
+            it.inputs.property("mokoSettingsVisibility", mrSettings.visibility)
         }
 
         apply(generationTask = genTask, project = project)
@@ -119,6 +111,12 @@ abstract class MRGenerator(
 
     protected open fun processMRClass(mrClass: TypeSpec.Builder) {}
     protected open fun getImports(): List<ClassName> = emptyList()
+
+    private fun setupGenerationDirs() {
+        sourceSet.addSourceDir(sourcesGenerationDir)
+        sourceSet.addResourcesDir(resourcesGenerationDir)
+        sourceSet.addAssetsDir(assetsGenerationDir)
+    }
 
     interface Generator : ObjectBodyExtendable {
         val mrObjectName: String
@@ -137,14 +135,14 @@ abstract class MRGenerator(
     interface SourceSet {
         val name: String
 
-        fun addSourceDir(directory: File)
-        fun addResourcesDir(directory: File)
-        fun addAssetsDir(directory: File)
+        fun addSourceDir(directory: Provider<Directory>)
+        fun addResourcesDir(directory: Provider<Directory>)
+        fun addAssetsDir(directory: Provider<Directory>)
     }
 
-    data class MRSettings(
-        val packageName: String,
-        val className: String,
-        val visibility: MRVisibility
-    )
+    interface MRSettings {
+        val packageName: Provider<String>
+        val className: Provider<String>
+        val visibility: Provider<MRVisibility>
+    }
 }

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/PluralsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/PluralsGenerator.kt
@@ -111,7 +111,7 @@ abstract class PluralsGenerator(
             AndroidPluralsGenerator(
                 pluralsFileTree = stringsFileTree,
                 strictLineBreaks = strictLineBreaks,
-                getAndroidRClassPackage = requireNotNull(info.getAndroidRClassPackage)
+                androidRClassPackageProvider = requireNotNull(info.androidRClassPackageProvider),
             )
 
         override fun createJvmGenerator() =

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/SourceInfo.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/SourceInfo.kt
@@ -5,12 +5,10 @@
 package dev.icerock.gradle.generator
 
 import org.gradle.api.file.SourceDirectorySet
-import java.io.File
+import org.gradle.api.provider.Provider
 
-data class SourceInfo(
-    val generatedDir: File,
-    val commonResources: SourceDirectorySet,
-    val mrClassPackage: String
-) {
-    var getAndroidRClassPackage: (() -> String)? = null
+interface SourceInfo {
+    val commonResources: SourceDirectorySet
+    val mrClassPackage: Provider<String>
+    var androidRClassPackageProvider: Provider<String>?
 }

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/StringsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/StringsGenerator.kt
@@ -91,7 +91,7 @@ abstract class StringsGenerator(
             AndroidStringsGenerator(
                 stringsFileTree = stringsFileTree,
                 strictLineBreaks = strictLineBreaks,
-                getAndroidRClassPackage = requireNotNull(info.getAndroidRClassPackage)
+                androidRClassPackageProvider = requireNotNull(info.androidRClassPackageProvider)
             )
 
         override fun createJsGenerator(): StringsGenerator =

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidFilesGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidFilesGenerator.kt
@@ -11,12 +11,13 @@ import dev.icerock.gradle.generator.FilesGenerator
 import dev.icerock.gradle.generator.NOPObjectBodyExtendable
 import dev.icerock.gradle.generator.ObjectBodyExtendable
 import org.gradle.api.file.FileTree
+import org.gradle.api.provider.Provider
 import java.io.File
 import java.util.Locale
 
 class AndroidFilesGenerator(
     inputFileTree: FileTree,
-    private val getAndroidRClassPackage: () -> String
+    private val androidRClassPackageProvider: Provider<String>,
 ) : FilesGenerator(inputFileTree), ObjectBodyExtendable by NOPObjectBodyExtendable() {
     override fun getClassModifiers(): Array<KModifier> = arrayOf(KModifier.ACTUAL)
 
@@ -26,7 +27,7 @@ class AndroidFilesGenerator(
         CodeBlock.of("FileResource(rawResId = R.raw.%L)", keyToResourceId(fileSpec.key))
 
     override fun getImports() = listOf(
-        ClassName(getAndroidRClassPackage(), "R")
+        ClassName(androidRClassPackageProvider.get(), "R")
     )
 
     override fun generateResources(

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidFontsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidFontsGenerator.kt
@@ -11,12 +11,13 @@ import dev.icerock.gradle.generator.FontsGenerator
 import dev.icerock.gradle.generator.NOPObjectBodyExtendable
 import dev.icerock.gradle.generator.ObjectBodyExtendable
 import org.gradle.api.file.FileTree
+import org.gradle.api.provider.Provider
 import java.io.File
 import java.util.Locale
 
 class AndroidFontsGenerator(
     inputFileTree: FileTree,
-    private val getAndroidRClassPackage: () -> String
+    private val androidRClassPackageProvider: Provider<String>,
 ) : FontsGenerator(inputFileTree), ObjectBodyExtendable by NOPObjectBodyExtendable() {
     override fun getClassModifiers(): Array<KModifier> = arrayOf(KModifier.ACTUAL)
 
@@ -27,7 +28,7 @@ class AndroidFontsGenerator(
     }
 
     override fun getImports(): List<ClassName> = listOf(
-        ClassName(getAndroidRClassPackage(), "R")
+        ClassName(androidRClassPackageProvider.get(), "R")
     )
 
     override fun generateResources(

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidImagesGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidImagesGenerator.kt
@@ -14,6 +14,7 @@ import dev.icerock.gradle.generator.ObjectBodyExtendable
 import dev.icerock.gradle.utils.svg
 import org.gradle.api.file.FileTree
 import org.gradle.api.logging.Logger
+import org.gradle.api.provider.Provider
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -23,7 +24,7 @@ import kotlin.reflect.full.functions
 
 class AndroidImagesGenerator(
     inputFileTree: FileTree,
-    private val getAndroidRClassPackage: () -> String,
+    private val androidRClassPackageProvider: Provider<String>,
     private val logger: Logger
 ) : ImagesGenerator(inputFileTree), ObjectBodyExtendable by NOPObjectBodyExtendable() {
     override fun getClassModifiers(): Array<KModifier> = arrayOf(KModifier.ACTUAL)
@@ -36,7 +37,7 @@ class AndroidImagesGenerator(
     }
 
     override fun getImports(): List<ClassName> = listOf(
-        ClassName(getAndroidRClassPackage(), "R")
+        ClassName(androidRClassPackageProvider.get(), "R")
     )
 
     override fun generateResources(

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidMRGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidMRGenerator.kt
@@ -10,11 +10,12 @@ import com.squareup.kotlinpoet.KModifier
 import dev.icerock.gradle.generator.MRGenerator
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.withType
-import java.io.File
 
 class AndroidMRGenerator(
-    generatedDir: File,
+    generatedDir: Provider<Directory>,
     sourceSet: SourceSet,
     mrSettings: MRSettings,
     generators: List<Generator>

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidPluralsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidPluralsGenerator.kt
@@ -15,12 +15,13 @@ import dev.icerock.gradle.generator.PluralMap
 import dev.icerock.gradle.generator.PluralsGenerator
 import org.apache.commons.lang3.StringEscapeUtils
 import org.gradle.api.file.FileTree
+import org.gradle.api.provider.Provider
 import java.io.File
 
 class AndroidPluralsGenerator(
     pluralsFileTree: FileTree,
     strictLineBreaks: Boolean,
-    private val getAndroidRClassPackage: () -> String
+    private val androidRClassPackageProvider: Provider<String>,
 ) : PluralsGenerator(pluralsFileTree, strictLineBreaks),
     ObjectBodyExtendable by NOPObjectBodyExtendable() {
     override fun getClassModifiers(): Array<KModifier> = arrayOf(KModifier.ACTUAL)
@@ -31,7 +32,7 @@ class AndroidPluralsGenerator(
         CodeBlock.of("PluralsResource(R.plurals.%L)", processKey(key))
 
     override fun getImports(): List<ClassName> = listOf(
-        ClassName(getAndroidRClassPackage(), "R")
+        ClassName(androidRClassPackageProvider.get(), "R")
     )
 
     override fun generateResources(

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidStringsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/android/AndroidStringsGenerator.kt
@@ -14,12 +14,13 @@ import dev.icerock.gradle.generator.ObjectBodyExtendable
 import dev.icerock.gradle.generator.StringsGenerator
 import org.apache.commons.text.StringEscapeUtils
 import org.gradle.api.file.FileTree
+import org.gradle.api.provider.Provider
 import java.io.File
 
 class AndroidStringsGenerator(
     stringsFileTree: FileTree,
     strictLineBreaks: Boolean,
-    private val getAndroidRClassPackage: () -> String
+    private val androidRClassPackageProvider: Provider<String>,
 ) : StringsGenerator(stringsFileTree, strictLineBreaks),
     ObjectBodyExtendable by NOPObjectBodyExtendable() {
 
@@ -31,7 +32,7 @@ class AndroidStringsGenerator(
         CodeBlock.of("StringResource(R.string.%L)", processKey(key))
 
     override fun getImports(): List<ClassName> = listOf(
-        ClassName(getAndroidRClassPackage(), "R")
+        ClassName(androidRClassPackageProvider.get(), "R")
     )
 
     override fun generateResources(

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/common/CommonMRGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/common/CommonMRGenerator.kt
@@ -8,12 +8,13 @@ import com.squareup.kotlinpoet.KModifier
 import dev.icerock.gradle.generator.MRGenerator
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
-import java.io.File
 
 class CommonMRGenerator(
-    generatedDir: File,
+    generatedDir: Provider<Directory>,
     sourceSet: SourceSet,
     mrSettings: MRSettings,
     generators: List<Generator>

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/js/JsFontsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/js/JsFontsGenerator.kt
@@ -14,15 +14,17 @@ import dev.icerock.gradle.generator.FontsGenerator
 import dev.icerock.gradle.generator.NOPObjectBodyExtendable
 import dev.icerock.gradle.generator.ObjectBodyExtendable
 import org.gradle.api.file.FileTree
+import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.provideDelegate
 import java.io.File
 
 class JsFontsGenerator(
     inputFileTree: FileTree,
-    mrClassPackage: String,
+    mrClassPackage: Provider<String>,
 ) : FontsGenerator(inputFileTree), ObjectBodyExtendable by NOPObjectBodyExtendable() {
 
-    private val flattenPackage: String = mrClassPackage.replace(".", "")
-    private val cssDeclarationsFileName: String = "$flattenPackage-generated-declarations.css"
+    private val flattenPackage: Provider<String> = mrClassPackage.map { it.replace(".", "") }
+    private val cssDeclarationsFileName: Provider<String> = flattenPackage.map { "$it-generated-declarations.css" }
 
     override fun getClassModifiers(): Array<KModifier> = arrayOf(KModifier.ACTUAL)
 
@@ -62,7 +64,7 @@ class JsFontsGenerator(
             FunSpec.builder("addFontsToPage")
                 .addCode(
                     "js(%S)",
-                    """require("$FONTS_DIR/$cssDeclarationsFileName")"""
+                    """require("$FONTS_DIR/${cssDeclarationsFileName.get()}")"""
                 ).build()
         )
     }
@@ -74,7 +76,7 @@ class JsFontsGenerator(
             file.copyTo(File(fontsDir, file.name))
         }
 
-        val cssDeclarationsFile = File(fontsDir, cssDeclarationsFileName)
+        val cssDeclarationsFile = File(fontsDir, cssDeclarationsFileName.get())
 
         val declarations = files
             .takeIf(List<*>::isNotEmpty)

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/js/JsPluralsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/js/JsPluralsGenerator.kt
@@ -19,16 +19,17 @@ import dev.icerock.gradle.generator.PluralsGenerator
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.gradle.api.file.FileTree
+import org.gradle.api.provider.Provider
 import java.io.File
 
 class JsPluralsGenerator(
     pluralsFileTree: FileTree,
-    mrClassPackage: String,
+    mrClassPackage: Provider<String>,
     strictLineBreaks: Boolean
 ) : PluralsGenerator(pluralsFileTree, strictLineBreaks),
     ObjectBodyExtendable by NOPObjectBodyExtendable() {
 
-    private val flattenClassPackage = mrClassPackage.replace(".", "")
+    private val flattenClassPackage = mrClassPackage.map { it.replace(".", "") }
 
     override fun getClassModifiers(): Array<KModifier> = arrayOf(KModifier.ACTUAL)
 
@@ -46,10 +47,10 @@ class JsPluralsGenerator(
             languages = languageMap.keys.toList(),
             folder = JsMRGenerator.LOCALIZATION_DIR,
             fallbackFilePropertyName = JsMRGenerator.PLURALS_FALLBACK_FILE_URL_PROPERTY_NAME,
-            fallbackFile = "${flattenClassPackage}_${JsMRGenerator.PLURALS_JSON_NAME}.json",
+            fallbackFile = "${flattenClassPackage.get()}_${JsMRGenerator.PLURALS_JSON_NAME}.json",
             supportedLocalesPropertyName = JsMRGenerator.SUPPORTED_LOCALES_PROPERTY_NAME,
             getFileNameForLanguage = { language ->
-                "${flattenClassPackage}_${JsMRGenerator.PLURALS_JSON_NAME}${language.jsResourcesSuffix}.json"
+                "${flattenClassPackage.get()}_${JsMRGenerator.PLURALS_JSON_NAME}${language.jsResourcesSuffix}.json"
             }
         )
         val languageKeys = languageMap[LanguageType.Base].orEmpty().keys
@@ -73,7 +74,7 @@ class JsPluralsGenerator(
         strings: Map<KeyType, PluralMap>
     ) {
         val fileDirName =
-            "${flattenClassPackage}_${JsMRGenerator.PLURALS_JSON_NAME}${language.jsResourcesSuffix}"
+            "${flattenClassPackage.get()}_${JsMRGenerator.PLURALS_JSON_NAME}${language.jsResourcesSuffix}"
 
         val localizationDir = File(resourcesGenerationDir, JsMRGenerator.LOCALIZATION_DIR).apply {
             mkdirs()

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/js/JsStringsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/js/JsStringsGenerator.kt
@@ -20,16 +20,17 @@ import dev.icerock.gradle.generator.js.JsMRGenerator.Companion.SUPPORTED_LOCALES
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.gradle.api.file.FileTree
+import org.gradle.api.provider.Provider
 import java.io.File
 
 class JsStringsGenerator(
     stringsFileTree: FileTree,
-    mrClassPackage: String,
+    mrClassPackage: Provider<String>,
     strictLineBreaks: Boolean
 ) : StringsGenerator(stringsFileTree, strictLineBreaks),
     ObjectBodyExtendable by NOPObjectBodyExtendable() {
 
-    private val flattenClassPackage = mrClassPackage.replace(".", "")
+    private val flattenClassPackage = mrClassPackage.map { it.replace(".", "") }
 
     override fun getClassModifiers(): Array<KModifier> = arrayOf(KModifier.ACTUAL)
 
@@ -47,10 +48,10 @@ class JsStringsGenerator(
             languages = languageMap.keys.toList(),
             folder = JsMRGenerator.LOCALIZATION_DIR,
             fallbackFilePropertyName = STRINGS_FALLBACK_FILE_URL_PROPERTY_NAME,
-            fallbackFile = "${flattenClassPackage}_${JsMRGenerator.STRINGS_JSON_NAME}.json",
+            fallbackFile = "${flattenClassPackage.get()}_${JsMRGenerator.STRINGS_JSON_NAME}.json",
             supportedLocalesPropertyName = SUPPORTED_LOCALES_PROPERTY_NAME,
             getFileNameForLanguage = { language ->
-                "${flattenClassPackage}_${JsMRGenerator.STRINGS_JSON_NAME}${language.jsResourcesSuffix}.json"
+                "${flattenClassPackage.get()}_${JsMRGenerator.STRINGS_JSON_NAME}${language.jsResourcesSuffix}.json"
             }
         )
         val languageKeys = languageMap[LanguageType.Base].orEmpty().keys
@@ -74,7 +75,7 @@ class JsStringsGenerator(
         strings: Map<KeyType, String>
     ) {
         val fileDirName =
-            "${flattenClassPackage}_${JsMRGenerator.STRINGS_JSON_NAME}${language.jsResourcesSuffix}"
+            "${flattenClassPackage.get()}_${JsMRGenerator.STRINGS_JSON_NAME}${language.jsResourcesSuffix}"
 
         val localizationDir = File(resourcesGenerationDir, JsMRGenerator.LOCALIZATION_DIR).apply {
             mkdirs()

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/jvm/ClassLoaderExtender.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/jvm/ClassLoaderExtender.kt
@@ -10,8 +10,9 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import dev.icerock.gradle.generator.ObjectBodyExtendable
+import org.gradle.api.provider.Provider
 
-class ClassLoaderExtender(private val mrClassName: String) : ObjectBodyExtendable {
+class ClassLoaderExtender(private val mrClassName: Provider<String>) : ObjectBodyExtendable {
     override fun extendObjectBodyAtStart(classBuilder: TypeSpec.Builder) {
         classBuilder.addProperty(
             PropertySpec.builder(
@@ -19,7 +20,7 @@ class ClassLoaderExtender(private val mrClassName: String) : ObjectBodyExtendabl
                 ClassName("java.lang", "ClassLoader"),
                 KModifier.OVERRIDE
             )
-                .initializer(CodeBlock.of("$mrClassName::class.java.classLoader"))
+                .initializer(CodeBlock.of("${mrClassName.get()}::class.java.classLoader"))
                 .build()
         )
     }

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/jvm/JvmPluralsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/jvm/JvmPluralsGenerator.kt
@@ -13,6 +13,7 @@ import dev.icerock.gradle.generator.ObjectBodyExtendable
 import dev.icerock.gradle.generator.PluralMap
 import dev.icerock.gradle.generator.PluralsGenerator
 import org.gradle.api.file.FileTree
+import org.gradle.api.provider.Provider
 import java.io.File
 
 class JvmPluralsGenerator(
@@ -22,7 +23,8 @@ class JvmPluralsGenerator(
 ) : PluralsGenerator(pluralsFileTree, strictLineBreaks),
     ObjectBodyExtendable by ClassLoaderExtender(mrSettings.className) {
 
-    private val flattenClassPackage = mrSettings.packageName.replace(".", "")
+    private val flattenClassPackage: Provider<String> = mrSettings.packageName
+        .map { it.replace(".", "") }
 
     override fun getClassModifiers(): Array<KModifier> = arrayOf(KModifier.ACTUAL)
 
@@ -41,7 +43,7 @@ class JvmPluralsGenerator(
         strings: Map<KeyType, PluralMap>
     ) {
         val fileDirName =
-            "${flattenClassPackage}_${JvmMRGenerator.PLURALS_BUNDLE_NAME}${language.jvmResourcesSuffix}"
+            "${flattenClassPackage.get()}_${JvmMRGenerator.PLURALS_BUNDLE_NAME}${language.jvmResourcesSuffix}"
 
         val localizationDir =
             File(resourcesGenerationDir, JvmMRGenerator.LOCALIZATION_DIR).apply { mkdirs() }

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/jvm/JvmStringsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/jvm/JvmStringsGenerator.kt
@@ -12,6 +12,7 @@ import dev.icerock.gradle.generator.MRGenerator
 import dev.icerock.gradle.generator.ObjectBodyExtendable
 import dev.icerock.gradle.generator.StringsGenerator
 import org.gradle.api.file.FileTree
+import org.gradle.api.provider.Provider
 import java.io.File
 
 class JvmStringsGenerator(
@@ -21,7 +22,8 @@ class JvmStringsGenerator(
 ) : StringsGenerator(stringsFileTree, strictLineBreaks),
     ObjectBodyExtendable by ClassLoaderExtender(mrSettings.className) {
 
-    private val flattenClassPackage = mrSettings.packageName.replace(".", "")
+    private val flattenClassPackage: Provider<String> = mrSettings.packageName
+        .map { it.replace(".", "") }
 
     override fun getClassModifiers(): Array<KModifier> = arrayOf(KModifier.ACTUAL)
 
@@ -40,7 +42,7 @@ class JvmStringsGenerator(
         strings: Map<KeyType, String>
     ) {
         val fileDirName =
-            "${flattenClassPackage}_${JvmMRGenerator.STRINGS_BUNDLE_NAME}${language.jvmResourcesSuffix}"
+            "${flattenClassPackage.get()}_${JvmMRGenerator.STRINGS_BUNDLE_NAME}${language.jvmResourcesSuffix}"
 
         val localizationDir = File(resourcesGenerationDir, JvmMRGenerator.LOCALIZATION_DIR).apply {
             mkdirs()

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/tasks/CopyExecutableResourcesToApp.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/tasks/CopyExecutableResourcesToApp.kt
@@ -4,18 +4,17 @@
 
 package dev.icerock.gradle.tasks
 
-import dev.icerock.gradle.utils.klibs
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
-import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 import org.jetbrains.kotlin.library.impl.KotlinLibraryLayoutImpl
 import java.io.File
 import java.io.FileFilter
 
-open class CopyExecutableResourcesToApp : DefaultTask() {
+abstract class CopyExecutableResourcesToApp : DefaultTask() {
     @get:Internal
-    lateinit var linkTask: KotlinNativeLink
+    abstract val klibs: ConfigurableFileCollection
 
     init {
         group = "moko-resources"
@@ -30,7 +29,7 @@ open class CopyExecutableResourcesToApp : DefaultTask() {
 
         val outputDir = File(buildProductsDir, contentsFolderPath)
 
-        linkTask.klibs
+        klibs
             .filter { library -> library.extension == "klib" }
             .filter(File::exists)
             .forEach { inputFile ->

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/tasks/GenerateMultiplatformResourcesTask.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/tasks/GenerateMultiplatformResourcesTask.kt
@@ -23,7 +23,7 @@ open class GenerateMultiplatformResourcesTask : DefaultTask() {
 
     @get:OutputDirectory
     val outputDirectory: File
-        get() = generator.outputDir
+        get() = generator.outputDir.get().asFile
 
     init {
         group = "moko-resources"

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/utils/TasksContainer.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/utils/TasksContainer.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.gradle.utils
+
+import org.gradle.api.Task
+import org.gradle.api.UnknownTaskException
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
+
+inline fun <reified T : Task> TaskContainer.maybeRegister(
+    taskName: String,
+    noinline configuration: T.() -> Unit
+): TaskProvider<T> = try {
+    named<T>(taskName)
+} catch (@Suppress("SwallowedException") ex: UnknownTaskException) {
+    register<T>(taskName, configuration)
+}


### PR DESCRIPTION
This is the second approach to fix #510, #531.
Configure the plugin more lazily, leverage Gradle Lazy Configuration API and Gradle live collections.

Android configuration is completely moved to `AndroidPluginLogic` to fix #119.

