### PR TITLE
Remove the compose.currentOs dependency from resources-compose

### DIFF
--- a/resources-compose/build.gradle.kts
+++ b/resources-compose/build.gradle.kts
@@ -52,7 +52,6 @@ kotlin {
         named("jvmMain") {
             dependencies {
                 api(compose.desktop.common)
-                implementation(compose.desktop.currentOs)
             }
         }
     }


### PR DESCRIPTION
Generally speaking, including `compose.currentOs` in a library is a very bad idea, as it forces the consumers to ship with the Skia implementation of the platform that the library was built with. Due to the fact that you use macOS in your CI and probably publish using that too, you're essentially shipping the compose Skia wrapper for macOS with moko-resources, regardless of what platform the consumer is using.