### PR TITLE
Only allow proper identifiers as strings keys

### DIFF
--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/EqualStringKeysException.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/EqualStringKeysException.kt
@@ -1,9 +1,0 @@
-/*
- * Copyright 2020 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package dev.icerock.gradle.generator
-
-class EqualStringKeysException(
-    val keys: List<String>
-) : Exception("Can't process keys which equals their value: ${keys.joinToString { "\"$it\"" }}")

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/InvalidKey.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/InvalidKey.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2020 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.gradle.generator
+
+class InvalidKey(
+    val keys: Iterable<String>,
+) : Exception(
+    "Keys must start with an ASCII letter or underscore and contain only ASCII letters," +
+            " underscores or digits: ${keys.joinToString { "\"$it\"" }}"
+)

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/StringsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/StringsGenerator.kt
@@ -59,12 +59,10 @@ abstract class StringsGenerator(
             mutableMap[name] = if (strictLineBreaks) value else value.removeLineWraps()
         }
 
-        val incorrectKeys = mutableMap
-            .filter { it.key == it.value }
-            .keys
-            .toList()
+        val regex = Regex("[a-zA-Z_][a-zA-Z_0-9]*")
+        val incorrectKeys = mutableMap.keys.filter { !regex.matches(it) }
         if (incorrectKeys.isNotEmpty()) {
-            throw EqualStringKeysException(incorrectKeys)
+            throw InvalidKey(incorrectKeys)
         }
 
         return mutableMap


### PR DESCRIPTION
The old code checked if key and text are identical, which made no sense as there is no such limitation. On the other hand it allowed keys like "test-key" which are invalid on Android.

The new code checks if the identifier starts with an ASCII letter or underscore and only contains ASCII lettes, digits or underscores.