### PR TITLE
Add `pluralStringResource` for Compose.

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,20 @@ iOS:
 let string = getMyPluralFormattedDesc(quantity: 10).localized()
 ```
 
+Compose:
+
+With compose, you can simply use `pluralStringResource`
+
+```kotlin
+Text(
+    text = pluralStringResource(
+        MR.plurals.runtime_format,
+        quantity,
+        quantity
+    )
+)
+```
+
 ### Example 5 - pass raw string or resource
 
 If we already use some resources as a placeholder value, we can use `StringDesc` to change the

--- a/resources-compose/src/commonMain/kotlin/dev/icerock/moko/resources/compose/PluralsResource.kt
+++ b/resources-compose/src/commonMain/kotlin/dev/icerock/moko/resources/compose/PluralsResource.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+package dev.icerock.moko.resources.compose
+
+import androidx.compose.runtime.Composable
+import dev.icerock.moko.resources.PluralsResource
+
+// These simple wrappers offer parity with the Compose `pluralStringResource` that accept
+// a `@PluralRes id` per https://developer.android.com/develop/ui/compose/resources#string-plurals
+// in order to more closely match vanilla Compose, improving discoverability.
+
+@Composable
+fun pluralStringResource(resource: PluralsResource, count: Int): String {
+    return stringResource(resource, count)
+}
+
+@Composable
+fun pluralStringResource(resource: PluralsResource, count: Int, vararg formatArgs: Any): String {
+    return stringResource(resource, count, *formatArgs)
+}


### PR DESCRIPTION
This makes using moko-resources plurals very similar to using plurals with compose per https://developer.android.com/develop/ui/compose/resources#string-plurals