### PR TITLE
Fix color resource ios

### DIFF
--- a/resources-compose/src/iosMain/kotlin/dev/icerock/moko/resources/compose/ColorResource.kt
+++ b/resources-compose/src/iosMain/kotlin/dev/icerock/moko/resources/compose/ColorResource.kt
@@ -25,7 +25,7 @@ actual fun colorResource(resource: ColorResource): Color {
     // TODO https://github.com/icerockdev/moko-resources/issues/443
     //  recompose when appearance changed (now not works in runtime!)
     val darkMode: Boolean = isSystemInDarkTheme()
-    return remember(darkMode) {
+    return remember(resource, darkMode) {
         val uiColor: UIColor = resource.getUIColor()
 
         memScoped {


### PR DESCRIPTION
Fixes #681 
Fixing composable colorResource function on iosMain to reevaluate remembered value based on resource passed in, when it changes