### PR TITLE
Minor argument rename for clarity and consistency

### DIFF
--- a/resources-compose/src/commonMain/kotlin/dev/icerock/moko/resources/compose/PluralsResource.kt
+++ b/resources-compose/src/commonMain/kotlin/dev/icerock/moko/resources/compose/PluralsResource.kt
@@ -11,11 +11,11 @@ import dev.icerock.moko.resources.PluralsResource
 // in order to more closely match vanilla Compose, improving discoverability.
 
 @Composable
-fun pluralStringResource(resource: PluralsResource, count: Int): String {
-    return stringResource(resource, count)
+fun pluralStringResource(resource: PluralsResource, quantity: Int): String {
+    return stringResource(resource, quantity)
 }
 
 @Composable
-fun pluralStringResource(resource: PluralsResource, count: Int, vararg formatArgs: Any): String {
-    return stringResource(resource, count, *formatArgs)
+fun pluralStringResource(resource: PluralsResource, quantity: Int, vararg formatArgs: Any): String {
+    return stringResource(resource, quantity, *formatArgs)
 }


### PR DESCRIPTION
Small follow-up from #679 that improves the argument name: `quantity` is better than `count` and matches what Composes uses at https://github.com/JetBrains/compose-multiplatform/blob/717f4f0e1383f57de74f85e53dbaa7ab3ead3afb/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/PluralStringResources.kt#L28