### PR TITLE
Fix build without cache for kotlin-ios-app sample

### DIFF
--- a/samples/kotlin-ios-app/xcode-project/TestProj.xcodeproj/project.pbxproj
+++ b/samples/kotlin-ios-app/xcode-project/TestProj.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				$TARGET_BUILD_DIR/$EXECUTABLE_PATH,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
fix #669 partly, only for kotlin-ios-app sample