### PR TITLE
The generate task now depends on the ResourceSourceDirectory

### DIFF
--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/extra/mokoResourcesGenTask.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/extra/mokoResourcesGenTask.kt
@@ -83,6 +83,9 @@ private fun registerGenerateTask(
 
         val files: Set<File> = resourcesSourceDirectory.srcDirs
         generateTask.ownResources.setFrom(files)
+        // make the generate task depend on tasks that the resourcesSourceDirectory depends on, e.g.
+        // resource generating tasks.
+        generateTask.dependsOn(resourcesSourceDirectory)
 
         generateTask.iosBaseLocalizationRegion.set(mrExtension.iosBaseLocalizationRegion)
         generateTask.resourcesClassName.set(mrExtension.resourcesClassName)


### PR DESCRIPTION
Make the generate task depend on tasks that the resourcesSourceDirectory depends on, e.g. resource generating tasks.
See https://github.com/icerockdev/moko-resources/issues/641#issuecomment-2091479298