### PR TITLE
Add tvOS support

### DIFF
--- a/resources-build-logic/src/main/kotlin/apple-main-convention.gradle.kts
+++ b/resources-build-logic/src/main/kotlin/apple-main-convention.gradle.kts
@@ -32,15 +32,15 @@ kotlin {
         }
     }
 
-    sourceSets.matching {
-        it.name == "watchosMain"
-    }.configureEach {
-        this.dependsOn(sourceSets.getByName("appleMain"))
-    }
+    val appleSourceSets = listOf("watchos", "tvos")
+    val appleMainSourceSets = appleSourceSets.map { "${it}Main" }
+    val appleTestSourceSets = appleSourceSets.map { "${it}Test" }
 
-    sourceSets.matching {
-        it.name == "tvosMain"
-    }.configureEach {
-        this.dependsOn(sourceSets.getByName("appleMain"))
-    }
+    sourceSets
+        .matching { it.name in appleMainSourceSets }
+        .configureEach { this.dependsOn(sourceSets.getByName("appleMain")) }
+
+    sourceSets
+        .matching { it.name in appleTestSourceSets }
+        .configureEach { this.dependsOn(sourceSets.getByName("appleTest")) }
 }

--- a/resources-build-logic/src/main/kotlin/apple-main-convention.gradle.kts
+++ b/resources-build-logic/src/main/kotlin/apple-main-convention.gradle.kts
@@ -37,4 +37,10 @@ kotlin {
     }.configureEach {
         this.dependsOn(sourceSets.getByName("appleMain"))
     }
+
+    sourceSets.matching {
+        it.name == "tvosMain"
+    }.configureEach {
+        this.dependsOn(sourceSets.getByName("appleMain"))
+    }
 }

--- a/resources-build-logic/src/main/kotlin/multiplatform-library-extended-convention.gradle.kts
+++ b/resources-build-logic/src/main/kotlin/multiplatform-library-extended-convention.gradle.kts
@@ -12,6 +12,10 @@ kotlin {
     watchosArm64()
     watchosSimulatorArm64()
 
+    tvosX64()
+    tvosArm64()
+    tvosSimulatorArm64()
+
     sourceSets {
         val commonMain by getting
 
@@ -29,6 +33,19 @@ kotlin {
         }
         val watchosSimulatorArm64Main by getting{
             dependsOn(watchosMain)
+        }
+
+        val tvosMain by creating {
+            dependsOn(commonMain)
+        }
+        val tvosX64Main by getting {
+            dependsOn(tvosMain)
+        }
+        val tvosArm64Main by getting {
+            dependsOn(tvosMain)
+        }
+        val tvosSimulatorArm64Main by getting {
+            dependsOn(tvosMain)
         }
     }
 }

--- a/resources-test/src/tvosMain/kotlin/dev/icerock/moko/resources/test/MockResourcesFactory.kt
+++ b/resources-test/src/tvosMain/kotlin/dev/icerock/moko/resources/test/MockResourcesFactory.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2024 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.resources.test
+
+import dev.icerock.moko.resources.FontResource
+import dev.icerock.moko.resources.ImageResource
+
+actual fun createImageResourceMock(): ImageResource = ImageResource("")
+actual fun createFontResourceMock(): FontResource = FontResource("")

--- a/resources/src/tvosMain/kotlin/dev/icerock/moko/resources/FileResource.tvos.kt
+++ b/resources/src/tvosMain/kotlin/dev/icerock/moko/resources/FileResource.tvos.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.resources
+
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCObjectVar
+import kotlinx.cinterop.UnsafeNumber
+import platform.Foundation.NSError
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.stringWithContentsOfFile
+
+@OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
+internal actual fun readContentOfFile(
+    filePath: String,
+    error: CPointer<ObjCObjectVar<NSError?>>?,
+): String? {
+    return NSString.stringWithContentsOfFile(
+        path = filePath,
+        encoding = NSUTF8StringEncoding,
+        error = error
+    )
+}

--- a/resources/src/tvosMain/kotlin/dev/icerock/moko/resources/ImageResource.kt
+++ b/resources/src/tvosMain/kotlin/dev/icerock/moko/resources/ImageResource.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2024 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.resources
+
+import platform.UIKit.UIImage
+
+actual class ImageResource(val assetImageName: String) {
+    fun toUIImage(): UIImage? {
+        return UIImage.imageNamed(name = assetImageName)
+    }
+}

--- a/resources/src/tvosMain/kotlin/dev/icerock/moko/resources/ImageResource.kt
+++ b/resources/src/tvosMain/kotlin/dev/icerock/moko/resources/ImageResource.kt
@@ -4,10 +4,18 @@
 
 package dev.icerock.moko.resources
 
+import platform.Foundation.NSBundle
 import platform.UIKit.UIImage
 
-actual class ImageResource(val assetImageName: String) {
+actual data class ImageResource(
+    val assetImageName: String,
+    val bundle: NSBundle = NSBundle.mainBundle
+) {
     fun toUIImage(): UIImage? {
-        return UIImage.imageNamed(name = assetImageName)
+        return UIImage.imageNamed(
+            name = assetImageName,
+            inBundle = bundle,
+            compatibleWithTraitCollection = null
+        )
     }
 }

--- a/resources/src/tvosMain/kotlin/dev/icerock/moko/resources/ResourceContainerExt.kt
+++ b/resources/src/tvosMain/kotlin/dev/icerock/moko/resources/ResourceContainerExt.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2024 IceRock MAG Inc. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.icerock.moko.resources
+
+actual fun ResourceContainer<ImageResource>.getImageByFileName(fileName: String): ImageResource? {
+    return ImageResource(fileName).let { imgRes ->
+        if (imgRes.toUIImage() != null) imgRes else null
+    }
+}

--- a/samples/resources-gallery/mpp-library/build.gradle.kts
+++ b/samples/resources-gallery/mpp-library/build.gradle.kts
@@ -18,6 +18,9 @@ allprojects {
             jvm()
             macosX64()
             macosArm64()
+            tvosX64()
+            tvosArm64()
+            tvosSimulatorArm64()
             js(IR) { browser() }
 
             explicitApi()
@@ -36,6 +39,16 @@ allprojects {
                 }
                 val macosArm64Main by getting {
                     dependsOn(macosMain)
+                }
+
+                val tvosMain by creating {
+                    dependsOn(commonMain.get())
+                }
+                val tvosX64Main by getting {
+                    dependsOn(tvosMain)
+                }
+                val tvosArm64Main by getting {
+                    dependsOn(tvosMain)
                 }
             }
         }

--- a/samples/resources-gallery/tvos-app/tvos-app.xcodeproj/project.pbxproj
+++ b/samples/resources-gallery/tvos-app/tvos-app.xcodeproj/project.pbxproj
@@ -1,0 +1,341 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		E7B8CD382D033E3D00915237 /* tvosApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B8CD372D033E3D00915237 /* tvosApp.swift */; };
+		E7B8CD3A2D033E3D00915237 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B8CD392D033E3D00915237 /* ContentView.swift */; };
+		E7B8CD3C2D033E4200915237 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E7B8CD3B2D033E4200915237 /* Assets.xcassets */; };
+		E7B8CD3F2D033E4200915237 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E7B8CD3E2D033E4200915237 /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		E7B8CD342D033E3D00915237 /* tvos-app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "tvos-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E7B8CD372D033E3D00915237 /* tvosApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tvosApp.swift; sourceTree = "<group>"; };
+		E7B8CD392D033E3D00915237 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		E7B8CD3B2D033E4200915237 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E7B8CD3E2D033E4200915237 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E7B8CD312D033E3D00915237 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		E7B8CD2B2D033E3D00915237 = {
+			isa = PBXGroup;
+			children = (
+				E7B8CD362D033E3D00915237 /* tvos-app */,
+				E7B8CD352D033E3D00915237 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		E7B8CD352D033E3D00915237 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E7B8CD342D033E3D00915237 /* tvos-app.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E7B8CD362D033E3D00915237 /* tvos-app */ = {
+			isa = PBXGroup;
+			children = (
+				E7B8CD372D033E3D00915237 /* tvosApp.swift */,
+				E7B8CD392D033E3D00915237 /* ContentView.swift */,
+				E7B8CD3B2D033E4200915237 /* Assets.xcassets */,
+				E7B8CD3D2D033E4200915237 /* Preview Content */,
+			);
+			path = "tvos-app";
+			sourceTree = "<group>";
+		};
+		E7B8CD3D2D033E4200915237 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				E7B8CD3E2D033E4200915237 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E7B8CD332D033E3D00915237 /* tvos-app */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E7B8CD422D033E4200915237 /* Build configuration list for PBXNativeTarget "tvos-app" */;
+			buildPhases = (
+				E7B8CD302D033E3D00915237 /* Sources */,
+				E7B8CD312D033E3D00915237 /* Frameworks */,
+				E7B8CD322D033E3D00915237 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "tvos-app";
+			productName = "tvos-app";
+			productReference = E7B8CD342D033E3D00915237 /* tvos-app.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E7B8CD2C2D033E3D00915237 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
+				LastUpgradeCheck = 1540;
+				TargetAttributes = {
+					E7B8CD332D033E3D00915237 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+				};
+			};
+			buildConfigurationList = E7B8CD2F2D033E3D00915237 /* Build configuration list for PBXProject "tvos-app" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E7B8CD2B2D033E3D00915237;
+			productRefGroup = E7B8CD352D033E3D00915237 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E7B8CD332D033E3D00915237 /* tvos-app */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E7B8CD322D033E3D00915237 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E7B8CD3F2D033E4200915237 /* Preview Assets.xcassets in Resources */,
+				E7B8CD3C2D033E4200915237 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E7B8CD302D033E3D00915237 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E7B8CD3A2D033E3D00915237 /* ContentView.swift in Sources */,
+				E7B8CD382D033E3D00915237 /* tvosApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		E7B8CD402D033E4200915237 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = appletvos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TVOS_DEPLOYMENT_TARGET = 17.5;
+			};
+			name = Debug;
+		};
+		E7B8CD412D033E4200915237 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = appletvos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				TVOS_DEPLOYMENT_TARGET = 17.5;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		E7B8CD432D033E4200915237 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"tvos-app/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "dev.icerock.moko.tvos-app";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Debug;
+		};
+		E7B8CD442D033E4200915237 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"tvos-app/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "dev.icerock.moko.tvos-app";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E7B8CD2F2D033E3D00915237 /* Build configuration list for PBXProject "tvos-app" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E7B8CD402D033E4200915237 /* Debug */,
+				E7B8CD412D033E4200915237 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E7B8CD422D033E4200915237 /* Build configuration list for PBXNativeTarget "tvos-app" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E7B8CD432D033E4200915237 /* Debug */,
+				E7B8CD442D033E4200915237 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = E7B8CD2C2D033E3D00915237 /* Project object */;
+}

--- a/samples/resources-gallery/tvos-app/tvos-app.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/samples/resources-gallery/tvos-app/tvos-app.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/samples/resources-gallery/tvos-app/tvos-app.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/samples/resources-gallery/tvos-app/tvos-app.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ]
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ]
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
@@ -1,0 +1,32 @@
+{
+  "assets" : [
+    {
+      "filename" : "App Icon - App Store.imagestack",
+      "idiom" : "tv",
+      "role" : "primary-app-icon",
+      "size" : "1280x768"
+    },
+    {
+      "filename" : "App Icon.imagestack",
+      "idiom" : "tv",
+      "role" : "primary-app-icon",
+      "size" : "400x240"
+    },
+    {
+      "filename" : "Top Shelf Image Wide.imageset",
+      "idiom" : "tv",
+      "role" : "top-shelf-image-wide",
+      "size" : "2320x720"
+    },
+    {
+      "filename" : "Top Shelf Image.imageset",
+      "idiom" : "tv",
+      "role" : "top-shelf-image",
+      "size" : "1920x720"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image Wide.imageset/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image Wide.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/ContentView.swift
+++ b/samples/resources-gallery/tvos-app/tvos-app/ContentView.swift
@@ -1,0 +1,18 @@
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/samples/resources-gallery/tvos-app/tvos-app/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/samples/resources-gallery/tvos-app/tvos-app/tvosApp.swift
+++ b/samples/resources-gallery/tvos-app/tvos-app/tvosApp.swift
@@ -1,0 +1,11 @@
+
+import SwiftUI
+
+@main
+struct tvosApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
In this PR I've tried to add tvOS targets to `moko-resources` project.

As mentioned in #739, the core implementation was already done in Apple generators, so I followed the approach in #648.

I've done the following:

- Added  tvOS targets and source seta to extended convention and Apple main convention.
- Implemented the expected classes and methods for tvOS targets.
- Added missing mocks for tvOS "resources-test" project.

I've tried to build the tvOS target in the sample ios app, but I'm getting the error
`No matching variant of dev.icerock.moko:resources:0.24.1 was found.`

Maybe you can suggest how I can test the tvOS target before it is added in the release version. 
 