### PR TITLE
Removed legacy ThreadLocal annotation on StringDesc's companion object

### DIFF
--- a/resources/src/appleMain/kotlin/dev/icerock/moko/resources/desc/StringDesc.kt
+++ b/resources/src/appleMain/kotlin/dev/icerock/moko/resources/desc/StringDesc.kt
@@ -57,7 +57,6 @@ actual interface StringDesc {
         abstract val locale: NSLocale
     }
 
-    @ThreadLocal
     actual companion object {
         actual var localeType: LocaleType = LocaleType.System
     }


### PR DESCRIPTION
Motivation of this PR is the issue: https://github.com/icerockdev/moko-resources/issues/544

The problem is:
_Because StringDesc's companion object marked as ThreadLocal it has different instances for each thread_

Since Kotlin 1.8.* released we don't need to use ThreadLocal annotation because of new memory manager.

I've checked that everything works fine without ThreadLocal annotation. 
Also all tests works good, `./local-check.sh` and `./local-samples-check.sh` are green :)

To test the mentioned issue (https://github.com/icerockdev/moko-resources/issues/544) is fixed, I've changed a sample a little bit. 
Attaching a patch I've used:
[patch.diff.zip](https://github.com/user-attachments/files/16679543/patch.diff.zip)