### PR TITLE
Add boolean property to allow webp format export

### DIFF
--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/MultiplatformResourcesPluginExtension.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/MultiplatformResourcesPluginExtension.kt
@@ -19,6 +19,7 @@ abstract class MultiplatformResourcesPluginExtension {
     abstract val resourcesVisibility: Property<MRVisibility>
     abstract val iosMinimalDeploymentTarget: Property<String>
     abstract val resourcesSourceSets: NamedDomainObjectContainer<SourceDirectorySet>
+    abstract val allowWebpImageFormat: Property<Boolean>
 
     fun Project.configureCopyXCFrameworkResources(xcFrameworkName: String = name) {
         NativeBuildType.values()
@@ -35,4 +36,5 @@ internal fun MultiplatformResourcesPluginExtension.setupConvention(project: Proj
     iosBaseLocalizationRegion.convention("en")
     resourcesVisibility.convention(MRVisibility.Public)
     iosMinimalDeploymentTarget.convention("9.0")
+    allowWebpImageFormat.convention(false)
 }

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/factory/ImageGeneratorFactory.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/factory/ImageGeneratorFactory.kt
@@ -31,6 +31,7 @@ internal class ImageGeneratorFactory(
     private val outputAssetsDir: File,
     private val kotlinPlatformType: KotlinPlatformType,
     private val kotlinKonanTarget: () -> KonanTarget,
+    private val allowWebpImageFormat: Boolean,
     private val androidRClassPackage: () -> String,
     private val logger: Logger
 ) {
@@ -44,7 +45,11 @@ internal class ImageGeneratorFactory(
             generator = ImageResourceGenerator(),
             platformResourceGenerator = createPlatformImageGenerator(),
             filter = {
-                include("images/**/*.png", "images/**/*.jpg", "images/**/*.svg")
+                val formats = mutableListOf("images/**/*.png", "images/**/*.jpg", "images/**/*.svg")
+                if (allowWebpImageFormat) {
+                    formats.add("images/**/*.webp")
+                }
+                include(formats)
             }
         )
     }

--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/tasks/GenerateMultiplatformResourcesTask.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/tasks/GenerateMultiplatformResourcesTask.kt
@@ -99,6 +99,9 @@ abstract class GenerateMultiplatformResourcesTask : DefaultTask() {
     @get:Input
     abstract val strictLineBreaks: Property<Boolean>
 
+    @get:Input
+    abstract val allowWebpImageFormat: Property<Boolean>
+
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles
@@ -229,8 +232,9 @@ abstract class GenerateMultiplatformResourcesTask : DefaultTask() {
             outputAssetsDir = outputAssetsDir.get().asFile,
             kotlinPlatformType = kotlinPlatformType,
             kotlinKonanTarget = ::kotlinKonanTarget,
+            allowWebpImageFormat = allowWebpImageFormat.get(),
             androidRClassPackage = androidRClassPackage::get,
-            logger = logger
+            logger = logger,
         ).create(),
         ColorGeneratorFactory(
             resourcesVisibility = resourcesVisibility.get(),


### PR DESCRIPTION
Related to this [issue](https://github.com/icerockdev/moko-resources/issues/566) 

Compose can read webp format and on iOS the size of the app with Compose Multiplatform is a problem (~25Mo in addition) 
Allow wepb will reduce significantly the size. 