### PR TITLE
Fix Escaped @

### DIFF
--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/utils/StringExt.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/utils/StringExt.kt
@@ -54,6 +54,7 @@ internal fun String.removeAndroidMirroringFormat(): String {
     return replace("""\'""", "'")
         .replace("""\"""", "\"")
         .replace("""\?""", "?")
+        .replace("""\@""", "@")
 }
 
 internal fun String.convertXmlStringToAndroidLocalization(): String {


### PR DESCRIPTION
We looked more into our translations to see what else our translation software was escaping, and found @ to be escaped as well.

This should be the last of it, thanks!