### PR TITLE
Fix '?' prefix being unescaped on Android target

### DIFF
--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/utils/StringExt.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/utils/StringExt.kt
@@ -57,6 +57,8 @@ internal fun String.removeAndroidMirroringFormat(): String {
         .replace("""\@""", "@")
 }
 
+private val androidLinkingCharacters = setOf('@', '?')
+
 internal fun String.convertXmlStringToAndroidLocalization(): String {
     //  Android resources should comply with requirements:
     //  https://developer.android.com/guide/topics/resources/string-resource#escaping_quotes
@@ -64,13 +66,7 @@ internal fun String.convertXmlStringToAndroidLocalization(): String {
         .unescapeXml(this)
         .replace("\n", "\\n")
         .let { StringEscapeUtils.escapeXml11(it) }
-        .let {
-            if (it.getOrNull(0) == '@') {
-                replaceFirst("@", """\@""")
-            } else {
-                it
-            }
-        }
+        .replaceFirstChar { if (it in androidLinkingCharacters) "\\$it" else "$it" }
         .replace("&quot;", "\\&quot;")
         .replace("&apos;", "\\&apos;")
 }

--- a/resources-generator/src/test/kotlin/dev/icerock/gradle/generator/stringsGenerator/XmlStringsToPlatformTest.kt
+++ b/resources-generator/src/test/kotlin/dev/icerock/gradle/generator/stringsGenerator/XmlStringsToPlatformTest.kt
@@ -124,10 +124,18 @@ class XmlStringsToPlatformTest {
     }
 
     @Test
-    fun stringLikeAndroidLinkOnStringAndroidTest() {
+    fun stringLikeAndroidResourceLinkOnStringAndroidTest() {
         assertEquals(
             expected = """\@same text""",
             actual = """@same text""".convertXmlStringToAndroidLocalization()
+        )
+    }
+
+    @Test
+    fun stringLikeAndroidAttributeLinkOnStringAndroidTest() {
+        assertEquals(
+            expected = """\?same text""",
+            actual = """?same text""".convertXmlStringToAndroidLocalization()
         )
     }
 }


### PR DESCRIPTION
Some of our translation (Arabic mostly) started with '\?' but after updating to `moko-resource:0.24.3` those started to become unescaped in android generated files. Which resulted in build failure.

This was a side effect of https://github.com/icerockdev/moko-resources/pull/761