### PR TITLE
doc: update swiftUI image extension helper in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,7 +680,8 @@ For SwiftUI, create this `Image` extension:
 ```swift
 extension Image {
     init(resource: KeyPath<MR.images, ImageResource>) {
-        self.init(uiImage: MR.images()[keyPath: resource].toUIImage()!)
+        let imageResource = MR.images()[keyPath: resource]
+        self.init(imageResource.assetImageName, bundle: imageResource.bundle)
     }
 }
 ```


### PR DESCRIPTION
On SwiftUI, we should generate the `Image` directly from the `ImageResource`. Loading svgs by making a `UIImage` first causes scaling issues resulting in blurry images.

Above: `Image(uiImage: MR.images()[keyPath: \.ic_close].toUIImage()!)`
Bottom: 
```
extension Image {
    init(resource: KeyPath<MR.images, ImageResource>) {
        let imageResource = MR.images()[keyPath: resource]
        self.init(imageResource.assetImageName, bundle: imageResource.bundle)
    }
}
```

<img width="408" alt="Screenshot 2025-07-03 at 14 48 40" src="https://github.com/user-attachments/assets/7f876539-00fd-4ccd-ad04-b9b38a4d064e" />
