### PR TITLE
Fix for copy script when using custom scheme configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ In Xcode add `Build Phase` (at end of list) with script:
     -Pmoko.resources.CONTENTS_FOLDER_PATH="$CONTENTS_FOLDER_PATH" \
     -Pkotlin.native.cocoapods.platform="$PLATFORM_NAME" \
     -Pkotlin.native.cocoapods.archs="$ARCHS" \
-    -Pkotlin.native.cocoapods.configuration="$CONFIGURATION" 
+    -Pkotlin.native.cocoapods.configuration="${KOTLIN_FRAMEWORK_BUILD_TYPE:-$CONFIGURATION}" 
 ```
 
 `YourFrameworkName` is name of your project framework. Please, see on a static framework warning for get correct task name.
@@ -220,7 +220,7 @@ In Xcode add `Build Phase` (at end of list) with script:
 ```shell script
 "$SRCROOT/../gradlew" -p "$SRCROOT/../" :yourframeworkproject:copyFrameworkResourcesToApp \
     -Pmoko.resources.PLATFORM_NAME="$PLATFORM_NAME" \
-    -Pmoko.resources.CONFIGURATION="$CONFIGURATION" \
+    -Pmoko.resources.CONFIGURATION="${KOTLIN_FRAMEWORK_BUILD_TYPE:-$CONFIGURATION}" \
     -Pmoko.resources.ARCHS="$ARCHS" \
     -Pmoko.resources.BUILT_PRODUCTS_DIR="$BUILT_PRODUCTS_DIR" \
     -Pmoko.resources.CONTENTS_FOLDER_PATH="$CONTENTS_FOLDER_PATH" 


### PR DESCRIPTION
Addresses https://github.com/icerockdev/moko-resources/issues/795

[KOTLIN_FRAMEWORK_BUILD_TYPE is required when using custom build configurations](https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-direct-integration.html#what-s-next) (diverging from Debug and Release) so this should save some head-scratching. Thank you @tamimattafi for creating the issue and resolving my problem!