### PR TITLE
[iOS] Add AssetResource key to produceState in readTextAsState()

### DIFF
--- a/resources-compose/src/appleMain/kotlin/dev/icerock/moko/resources/compose/AssetResource.kt
+++ b/resources-compose/src/appleMain/kotlin/dev/icerock/moko/resources/compose/AssetResource.kt
@@ -11,7 +11,7 @@ import dev.icerock.moko.resources.AssetResource
 
 @Composable
 actual fun AssetResource.readTextAsState(): State<String?> {
-    return produceState<String?>(null) {
+    return produceState<String?>(null, this) {
         value = readText()
     }
 }


### PR DESCRIPTION
Fix for #853

## Description

Fixes the iOS implementation of `AssetResource.readTextAsState()` by adding the resource as a key to `produceState()`

## Problem

The iOS implementation was missing keys in `produceState()`, causing the state to be cached incorrectly when the same composable switches between different `AssetResource` objects. This resulted in the first loaded resource being reused for all subsequent calls

## Solution

Added `this` (the `AssetResource` itself) as a key to `produceState()`, matching the Android/JVM/JS implementation which includes `this` and `context` (Android only) as keys